### PR TITLE
Adding MultiAccounts Support

### DIFF
--- a/bless.js
+++ b/bless.js
@@ -1,16 +1,10 @@
 const axios = require('axios');
-const set = require('./config');
-const {
-    NODE_IDS
-} = require('./idnode');
+const { accounts, getRandomUserAgent, proxyFile } = require('./config');
+const { NODE_IDS } = require('./idnode');
 const fs = require('fs');
 const readline = require('readline');
-const {
-    SocksProxyAgent
-} = require('socks-proxy-agent');
-const {
-    HttpsProxyAgent
-} = require('https-proxy-agent');
+const { SocksProxyAgent } = require('socks-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 let CoderMarkPrinted = false;
 
@@ -35,8 +29,8 @@ function CoderMark() {
 ┃╭━━┫┃┃┃╭┫╭╮┃╭╮┃╭╮┫╭━━┫┃┃┃╱┃┃╭╮┫╭╮╮${cl.br}
 ┃┃╱╱┃╰╯┃┃┃╰╯┃╰╯┃┃┃┃┃╱╱┃╰┫╰━╯┃┃┃┃┃┃┃
 ╰╯╱╱╰━━┻╯╰━╮┣━━┻╯╰┻╯╱╱╰━┻━╮╭┻╯╰┻╯╰╯${cl.rt}
-╱╱╱╱╱╱╱╱╱╱╱┃┃╱╱╱╱╱╱╱╱╱╱╱╭━╯┃
-╱╱╱╱╱╱╱╱╱╱╱╰╯╱╱╱╱╱╱╱╱╱╱╱╰━━╯
+╱╱╱╱╱╱╱╱╱╱╱┃┃╱╱╱╱╱╱╱╱╱╱╭━╯┃
+╱╱╱╱╱╱╱╱╱╱╱╰╯╱╱╱╱╱╱╱╱╱╱╰━━╯
 \n${cl.gb}${cl.gr}blessnetwork Bot ${cl.rt}${cl.gb}v0.1.2${cl.rt}
         `);
         CoderMarkPrinted = true;
@@ -44,15 +38,14 @@ function CoderMark() {
 }
 
 const BASE_API_URL = "https://gateway-run.bls.dev";
-const AUTH_TOKEN = set.AUTH_TOKEN;
-const HEADERS = {
-    "Authorization": `Bearer ${AUTH_TOKEN}`,
+const HEADERS_TEMPLATE = (authToken) => ({
+    "Authorization": `Bearer ${authToken}`,
     "Content-Type": "application/json",
     "Access-Control-Allow-Origin": "*",
     "sec-fetch-mode": "cors",
     "sec-fetch-site": "cross-site",
-    "user-agent": set.UserAgent
-};
+    "user-agent": getRandomUserAgent()
+});
 
 const HealthHeader = {
     "Host": "gateway-run.bls.dev",
@@ -66,7 +59,7 @@ async function checkGlobalHealth() {
     try {
         const response = await axios.get(url, {
             headers: HealthHeader,
-            timeout: 10000 // Add timeout of 10 seconds
+            timeout: 10000 // 10 seconds timeout
         });
         const healthStatus = response.data.status;
         console.log(`${cl.yl})>${cl.rt} Global Health Check: ${cl.gr}${healthStatus}${cl.rt}`);
@@ -81,12 +74,12 @@ async function checkGlobalHealth() {
     }
 }
 
-async function pingSession(nodeId, proxy) {
+async function pingSession(nodeId, headers, proxy) {
     const url = `${BASE_API_URL}/api/v1/nodes/${nodeId}/ping`;
     let agent;
     const config = {
-        headers: HEADERS,
-        timeout: 30000 // Add timeout of 30 seconds
+        headers: headers,
+        timeout: 30000 // 30 seconds timeout
     };
 
     if (proxy) {
@@ -104,74 +97,70 @@ async function pingSession(nodeId, proxy) {
         return true;
     } catch (error) {
         if (error.response) {
-            // Handle Cloudflare or other specific errors
+            // Handle specific HTTP errors
             if (error.response.status === 403 && error.response.data.includes('Cloudflare')) {
                 console.log(`${cl.yl})>${cl.rt} Ping failed ${cl.gr}-> ${cl.br}${nodeId}: ${cl.red}Cloudflare protection detected${cl.rt}`);
-                await new Promise(resolve => setTimeout(resolve, 300000));
+                await new Promise(resolve => setTimeout(resolve, 300000)); // Wait 5 minutes
                 return false;
             }
-            // Handle rate limiting
             if (error.response.status === 429) {
                 console.log(`${cl.yl})>${cl.rt} Rate limit reached ${cl.gr}-> ${cl.br}${nodeId}: ${cl.red}Too many requests${cl.rt}`);
-                await new Promise(resolve => setTimeout(resolve, 120000));
+                await new Promise(resolve => setTimeout(resolve, 120000)); // Wait 2 minutes
                 return false;
             }
-            // Handle authentication errors
             if (error.response.status === 401 || error.response.status === 403) {
                 console.log(`${cl.yl})>${cl.rt} Authentication failed ${cl.gr}-> ${cl.br}${nodeId}: ${cl.red}Please check your AUTH_TOKEN${cl.rt}`);
                 process.exit(1);
             }
-            // Handle server errors
             if (error.response.status >= 500) {
                 console.log(`${cl.yl})>${cl.rt} Server error ${cl.gr}-> ${cl.br}${nodeId}: ${cl.red}${error.response.status}${cl.rt}`);
-                await new Promise(resolve => setTimeout(resolve, 60000));
+                await new Promise(resolve => setTimeout(resolve, 60000)); // Wait 1 minute
                 return false;
             }
-            // Log other errors with response
+            // Log other response errors
             console.log(`${cl.yl})>${cl.rt} Ping failed ${cl.gr}-> ${cl.br}${nodeId}: ${cl.red}${error.response.status}${cl.rt}`);
             if (error.response.data) {
                 console.log(`${cl.yl})>${cl.rt} Error details: ${cl.red}${JSON.stringify(error.response.data)}${cl.rt}`);
             }
         } else if (error.request) {
-            // Handle network errors
+            // Network errors
             console.log(`${cl.yl})>${cl.rt} Network error ${cl.gr}-> ${cl.br}${nodeId}: ${cl.red}No response received${cl.rt}`);
-            await new Promise(resolve => setTimeout(resolve, 30000));
+            await new Promise(resolve => setTimeout(resolve, 30000)); // Wait 30 seconds
         } else {
-            // Handle other errors
+            // Other errors
             console.log(`${cl.yl})>${cl.rt} Unknown error ${cl.gr}-> ${cl.br}${nodeId}: ${cl.red}${error.message}${cl.rt}`);
         }
         return false;
     }
 }
 
-async function manageNode(nodeId, proxy) {
+async function manageNode(nodeId, headers, proxy) {
     let consecutiveFailures = 0;
     const MAX_FAILURES = 5;
 
     try {
         while (true) {
             console.log(`${cl.yl})>${cl.rt} Pinging Node ${cl.gr}->${cl.br} ${nodeId}${cl.rt}`);
-            const success = await pingSession(nodeId, proxy);
+            const success = await pingSession(nodeId, headers, proxy);
             
             if (!success) {
                 consecutiveFailures++;
                 if (consecutiveFailures >= MAX_FAILURES) {
                     console.log(`${cl.red}Too many consecutive failures for Node ${nodeId}. Waiting 5 minutes before continuing...${cl.rt}`);
-                    await new Promise(resolve => setTimeout(resolve, 300000));
+                    await new Promise(resolve => setTimeout(resolve, 300000)); // Wait 5 minutes
                     consecutiveFailures = 0;
                 }
             } else {
                 consecutiveFailures = 0;
             }
 
-            await new Promise(resolve => setTimeout(resolve, 60000));
+            await new Promise(resolve => setTimeout(resolve, 60000)); // Wait 1 minute
         }
     } catch (error) {
         console.log(`${cl.red}An error occurred for Node ${nodeId}: ${error}${cl.rt}`);
     }
 }
 
-// Update globalHealthMonitor function to accept proxy parameter
 async function globalHealthMonitor(proxy) {
     let consecutiveFailures = 0;
     const MAX_FAILURES = 3;
@@ -208,11 +197,11 @@ async function globalHealthMonitor(proxy) {
                 consecutiveFailures++;
                 if (consecutiveFailures >= MAX_FAILURES) {
                     console.log(`${cl.red}Global health check failed ${MAX_FAILURES} times in a row. Waiting 10 minutes...${cl.rt}`);
-                    await new Promise(resolve => setTimeout(resolve, 600000));
+                    await new Promise(resolve => setTimeout(resolve, 600000)); // Wait 10 minutes
                     consecutiveFailures = 0;
                 }
             }
-            await new Promise(resolve => setTimeout(resolve, 300000));
+            await new Promise(resolve => setTimeout(resolve, 300000)); // Wait 5 minutes
         }
     } catch (error) {
         console.log(`${cl.red}An error occurred in global health monitoring: ${error}${cl.rt}`);
@@ -223,7 +212,7 @@ async function readLines(filename) {
     try {
         const data = await fs.promises.readFile(filename, 'utf-8');
         console.log(`${cl.yl}[+]${cl.rt} Loaded data from ${filename}`);
-        return data.split('\n').filter(line => line.trim());
+        return data.split('\n').map(line => line.trim()).filter(line => line);
     } catch (error) {
         console.log(`${cl.red}Failed to read ${filename}: ${error.message}${cl.rt}`);
         return [];
@@ -249,7 +238,7 @@ async function getProxyIP(proxy) {
         const maskedIp = response.data.ip.replace(/(\d+\.\d+\.\d+)\.(\d+)/, '$1.***');
         return response.data;
     } catch (error) {
-        console.log(`${cl.yl})>${cl.rt} Skipping proxy ${proxy} due to connection error: ${error.message}`);
+        console.log(`${cl.yl})>${cl.rt} Skipping proxy ${proxy} due to connection error: ${error.message}${cl.rt}`);
         return null;
     }
 }
@@ -269,9 +258,9 @@ async function main() {
 
         if (answer === '2') {
             console.log(`\n${cl.yl})>${cl.gr} Proxy connection mode enabled.${cl.rt}`);
-            console.log(`\n${cl.yl}[+]${cl.yl} Please wait...${cl.rt}\n`);
+            console.log(`\n${cl.yl}[+]${cl.rt} Please wait...${cl.rt}\n`);
             
-            const proxies = await readLines(set.proxyFile);
+            const proxies = await readLines(proxyFile);
             if (proxies.length === 0) {
                 console.log(`${cl.red}No proxies found. Exiting...${cl.rt}`);
                 rl.close();
@@ -280,28 +269,51 @@ async function main() {
 
             console.log(`${cl.yl}[+]${cl.rt} Loaded ${proxies.length} proxies`);
             console.log(`${cl.yl}[+]${cl.rt} Loaded data from idnode.js`);
-            console.log(`${cl.yl}[+]${cl.rt} Loaded ${NODE_IDS.length} nodeId\n`);
+            console.log(`${cl.yl}[+]${cl.rt} Loaded ${NODE_IDS.length} nodeIds\n`);
 
-            if (proxies.length !== NODE_IDS.length) {
-                console.log(`${cl.red}Number of proxies (${proxies.length}) does not match number of NODE_IDS (${NODE_IDS.length}). Exiting...${cl.rt}`);
+            const expectedProxies = accounts.length * 5;
+            if (proxies.length < expectedProxies) {
+                console.log(`${cl.red}Insufficient number of proxies. Required: ${expectedProxies}, Found: ${proxies.length}. Exiting...${cl.rt}`);
                 rl.close();
                 return;
             }
-    
+
+            const proxyGroups = [];
+            for (let i = 0; i < accounts.length; i++) {
+                proxyGroups.push(proxies.slice(i * 5, (i + 1) * 5));
+            }
+
+            const nodeGroups = [];
+            for (let i = 0; i < accounts.length; i++) {
+                nodeGroups.push(NODE_IDS.slice(i * 5, (i + 1) * 5));
+            }
+
             const promises = [];
-            for (let i = 0; i < NODE_IDS.length; i++) {
-                const nodeId = NODE_IDS[i];
-                const proxy = proxies[i];
-                const proxyInfo = await getProxyIP(proxy);
-                
-                // Start a health monitor for each NODE_IDS through proxy
-                promises.push(globalHealthMonitor(proxy));
-                
-                if (proxyInfo) {
-                    const maskedIp = proxyInfo.ip.replace(/(\d+\.\d+\.\d+)\.(\d+)/, '$1.***');
-                    console.log(`${cl.yl})>${cl.rt} Node ${cl.am}${nodeId} ${cl.rt}using proxyIP: ${cl.gr}${maskedIp}${cl.rt}`);
-                    // fix connection through proxy.
-                    promises.push(manageNode(nodeId, proxy));
+            for (let i = 0; i < accounts.length; i++) {
+                const account = accounts[i];
+                const accountProxies = proxyGroups[i];
+                const accountNodes = nodeGroups[i];
+                const authToken = account.AUTH_TOKEN;
+                if (!authToken) {
+                    console.log(`${cl.red}AUTH_TOKEN for Account ${i + 1} is missing. Skipping this account.${cl.rt}`);
+                    continue;
+                }
+                const headers = HEADERS_TEMPLATE(authToken);
+
+                // Start global health monitor for this account
+                const proxyForHealth = accountProxies[0]; // Use the first proxy for health checks
+                promises.push(globalHealthMonitor(proxyForHealth));
+
+                for (let j = 0; j < accountNodes.length; j++) {
+                    const nodeId = accountNodes[j];
+                    const proxy = accountProxies[j];
+                    const proxyInfo = await getProxyIP(proxy);
+                    
+                    if (proxyInfo) {
+                        const maskedIp = proxyInfo.ip.replace(/(\d+\.\d+\.\d+)\.(\d+)/, '$1.***');
+                        console.log(`${cl.yl})>${cl.rt} Node ${cl.am}${nodeId}${cl.rt} using proxyIP: ${cl.gr}${maskedIp}${cl.rt}`);
+                        promises.push(manageNode(nodeId, headers, proxy));
+                    }
                 }
             }
             
@@ -309,10 +321,25 @@ async function main() {
         } else {
             console.log(`\n${cl.yl})>${cl.gr} Direct connection mode enabled.${cl.rt}\n`);
             console.log(`${cl.yl}[+]${cl.rt} Loaded data from idnode.js`);
-            console.log(`${cl.yl}[+]${cl.rt} Loaded ${NODE_IDS.length} nodeId\n`);
+            console.log(`${cl.yl}[+]${cl.rt} Loaded ${NODE_IDS.length} nodeIds\n`);
             
-            const promises = [globalHealthMonitor()];
-            NODE_IDS.forEach(nodeId => promises.push(manageNode(nodeId, null)));
+            const promises = [];
+            for (let i = 0; i < accounts.length; i++) {
+                const account = accounts[i];
+                const authToken = account.AUTH_TOKEN;
+                if (!authToken) {
+                    console.log(`${cl.red}AUTH_TOKEN for Account ${i + 1} is missing. Skipping this account.${cl.rt}`);
+                    continue;
+                }
+                const headers = HEADERS_TEMPLATE(authToken);
+                // Start a single global health monitor for direct connection
+                promises.push(globalHealthMonitor(null));
+
+                const accountNodes = NODE_IDS.slice(i * 5, (i + 1) * 5);
+                for (const nodeId of accountNodes) {
+                    promises.push(manageNode(nodeId, headers, null));
+                }
+            }
             await Promise.all(promises);
         }
     } catch (error) {
@@ -329,7 +356,7 @@ process.on('SIGINT', () => {
     process.exit(0);
 });
 
-// Add these error handlers at the end
+// Error handlers
 process.on('unhandledRejection', (reason, promise) => {
     console.log(`${cl.red}Unhandled Rejection at:${cl.rt}`, promise, `${cl.red}reason:${cl.rt}`, reason);
 });

--- a/config.js
+++ b/config.js
@@ -1,10 +1,47 @@
 //configuration
 
-const set = {
-	AUTH_TOKEN: '',  // Replace with your Bearer token
-	UserAgent: '', // Replace with your UserAgent
-	proxyFile: 'proxy.txt', // your Path to Proxy.txt file
+const accounts = [
+    {
+        AUTH_TOKEN: 'xxx', // Bearer token for Account 1
+    },
+    {
+        AUTH_TOKEN: 'xxx', // Bearer token for Account 2
+    },
+    // Add more accounts as needed
+];
 
-	};
+const USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Edge/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Edge/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Edge/120.0.0.0",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.1 Safari/605.1.15",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.3",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 OPR/114.0.0.",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.3",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.3",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 AtContent/95.5.5462.5",
+];
 
-module.exports = set;
+/**
+ * Returns a random User-Agent string from the USER_AGENTS array.
+ * @returns {string} A random User-Agent string.
+ * @throws {Error} If the USER_AGENTS array is empty.
+ */
+function getRandomUserAgent() {
+    if (USER_AGENTS.length === 0) {
+        throw new Error('User agents list is empty.');
+    }
+    const index = Math.floor(Math.random() * USER_AGENTS.length);
+    return USER_AGENTS[index];
+}
+
+const proxyFile = 'proxy.txt'; // Path to your proxy.txt file
+
+module.exports = {
+    accounts,
+    getRandomUserAgent,
+    proxyFile,
+};

--- a/idnode.js
+++ b/idnode.js
@@ -1,12 +1,22 @@
 // idnode.js
 const NODE_IDS = [
-    "node_id_1",
-    "node_id_2",
-    "node_id_3"
-    // Add more node IDs as needed
+    // Account 1
+    "node_id_1_account1",
+    "node_id_2_account1",
+    "node_id_3_account1",
+    "node_id_4_account1",
+    "node_id_5_account1",
+    
+    // Account 2
+    "node_id_1_account2",
+    "node_id_2_account2",
+    "node_id_3_account2",
+    "node_id_4_account2",
+    "node_id_5_account2",
+    
+    // Add more node IDs for additional accounts as needed
 ];
 
 module.exports = {
     NODE_IDS
 };
-


### PR DESCRIPTION
# The rules are:
- 1 account 5 nodeIds
- for proxy taken from proxy list in proxy.txt with the provision that the first account takes a list of proxy numbers 1-5, the second account takes a list of proxy numbers 6-10 and so on.
- using random useragent (so users only need to prepare Auth_Token and 5 NodeId for each account)